### PR TITLE
Update sets on slider input change using arrows

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,6 +177,11 @@
 					$('#' + shortTitle + "-" + shortExerciseName + '-warmup')
 						.data('workouts', warmupApp.programs[i].exercises[j]);
 
+					// Update warmup sets on slider input change using arrows  
+					$('.ui-slider-input').live('change', function(){
+						updateWorkout($(this).parent().siblings('ul'), this.value);
+					});
+
 					$('.ui-slider').live('mouseup', function() {
 						updateWorkout($(this).parent().siblings('ul'), $(this).siblings('input').val());
 					});


### PR DESCRIPTION
Warmup sets don't update when weight is changed using input arrow buttons. In a desktop browser you have to click elsewhere to update sets.