### PR TITLE
Load external stylesheets and scripts with HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,14 +6,14 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1"> 
 	<title>WarmupReps.com</title> 
-	<link rel="stylesheet" href="http://code.jquery.com/mobile/1.0.1/jquery.mobile-1.0.1.min.css" />
+	<link rel="stylesheet" href="https://code.jquery.com/mobile/1.0.1/jquery.mobile-1.0.1.min.css" />
 	<link rel="apple-touch-icon" href="/images/apple-touch-icon-57x57.png" />
 	<link rel="apple-touch-icon" sizes="72x72" href="/images/apple-touch-icon-72x72.png" />
 	<link rel="apple-touch-icon" sizes="114x114" href="/images/apple-touch-icon-114x114.png" />
 	<meta name="apple-mobile-web-app-capable" content="yes">
-	<script src="http://code.jquery.com/jquery-1.6.4.min.js"></script>
+	<script src="https://code.jquery.com/jquery-1.6.4.min.js"></script>
 	<script src="scripts/jquery.cookie.js"></script>
-	<script src="http://code.jquery.com/mobile/1.0.1/jquery.mobile-1.0.1.min.js"></script>
+	<script src="https://code.jquery.com/mobile/1.0.1/jquery.mobile-1.0.1.min.js"></script>
 
 	<style type="text/css">
 		/* issue 1259, pull request https://github.com/jquery/jquery-mobile/pull/2533 */


### PR DESCRIPTION
Hey Nicolas, thanks for making this website! I'd been using it and finding it quite convenient, but it seems that the site has broken recently due to not being able to load its stylesheet and scripts:
<img width="1329" height="670" alt="image" src="https://github.com/user-attachments/assets/a89056c0-8412-4f09-bf55-7a18a4804457" />
<img width="1479" height="358" alt="image" src="https://github.com/user-attachments/assets/1a40e99a-3759-4350-8282-fc33a7639c43" />

This PR changes the URLs to use HTTPs, fixing the issue. I've deployed my fork with CF Pages to test it; you can view it here: https://warmup-reps.pages.dev/